### PR TITLE
Cleanup: Small nit on doNotProcessChannels

### DIFF
--- a/app.go
+++ b/app.go
@@ -90,7 +90,7 @@ var slackRetryErrors = map[string]string{
 
 var doNotProcessChannels = map[string]time.Time{}
 
-func CheckError(err string, channel string) (retryable bool, pause bool, description string) {
+func CheckError(err string) (retryable bool, pause bool, description string) {
 	// Special case for channel_not_found, we don't want to retry this one right away.
 	// We are making it a 'soft failure' so that we don't keep retrying it for a period of time for any message that is sent to a channel that doesn't exist.
 	if err == "channel_not_found" {
@@ -207,7 +207,7 @@ func (app *App) processQueue(ctx context.Context, maxRetries int, initialBackoff
 				err := app.messenger.PostMessage(msg, slackPostMessageURL, tokenFlag)
 				//nolint:nestif // but simplify by not having else at least.
 				if err != nil {
-					retryable, pause, description := CheckError(err.Error(), msg.Channel)
+					retryable, pause, description := CheckError(err.Error())
 
 					// We keep track of channels that are paused in a map, and we will retry it after a period of time.
 					if pause {

--- a/app.go
+++ b/app.go
@@ -95,7 +95,6 @@ func CheckError(err string, channel string) (retryable bool, pause bool, descrip
 	// We are making it a 'soft failure' so that we don't keep retrying it for a period of time for any message that is sent to a channel that doesn't exist.
 	// We keep track of said channel in a map, and we will retry it after a period of time.
 	if err == "channel_not_found" {
-		doNotProcessChannels[channel] = time.Now()
 		return true, true, "Channel not found"
 	}
 
@@ -212,6 +211,7 @@ func (app *App) processQueue(ctx context.Context, maxRetries int, initialBackoff
 					retryable, pause, description := CheckError(err.Error(), msg.Channel)
 
 					if pause {
+						doNotProcessChannels[msg.Channel] = time.Now()
 						log.S(log.Warning, "Channel not found, pausing for 15 minutes", log.String("channel", msg.Channel))
 						app.metrics.RequestsNotProcessed.WithLabelValues(msg.Channel).Inc()
 						break

--- a/app.go
+++ b/app.go
@@ -93,7 +93,6 @@ var doNotProcessChannels = map[string]time.Time{}
 func CheckError(err string, channel string) (retryable bool, pause bool, description string) {
 	// Special case for channel_not_found, we don't want to retry this one right away.
 	// We are making it a 'soft failure' so that we don't keep retrying it for a period of time for any message that is sent to a channel that doesn't exist.
-	// We keep track of said channel in a map, and we will retry it after a period of time.
 	if err == "channel_not_found" {
 		return true, true, "Channel not found"
 	}
@@ -210,6 +209,7 @@ func (app *App) processQueue(ctx context.Context, maxRetries int, initialBackoff
 				if err != nil {
 					retryable, pause, description := CheckError(err.Error(), msg.Channel)
 
+					// We keep track of channels that are paused in a map, and we will retry it after a period of time.
 					if pause {
 						doNotProcessChannels[msg.Channel] = time.Now()
 						log.S(log.Warning, "Channel not found, pausing for 15 minutes", log.String("channel", msg.Channel))


### PR DESCRIPTION
Small NIT about what I was saying here: https://github.com/fortio/slack-proxy/pull/12#issuecomment-1774017107 

Can revert if this doesn't make sense, made the MR because it's easier to explain the change with MR than in comments. 

But the reasoning was, `CheckError` felt a bit more of a no state change function. So wanted to move the `doNotProcessChannels` addition at caller.  