### PR TITLE
Feature: Added slack tokens and pod name to get token index

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,6 @@ func getSlackTokens() []string {
 	}
 
 	tokens := strings.Split(tokensEnv, ",")
-
 	for i, token := range tokens {
 		tokens[i] = strings.TrimSpace(token)
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -63,7 +62,7 @@ type App struct {
 func podIndex() (int, error) {
 	podName := os.Getenv("HOSTNAME")
 	if podName == "" {
-		return 0, errors.New("HOSTNAME environment variable not set")
+		return 0, fmt.Errorf("HOSTNAME environment variable not set")
 	}
 
 	lastDash := strings.LastIndex(podName, "-")

--- a/main.go
+++ b/main.go
@@ -68,13 +68,13 @@ func podIndex() (int, error) {
 
 	lastDash := strings.LastIndex(podName, "-")
 	if lastDash == -1 || lastDash == len(podName)-1 {
-		return 0, errors.New("invalid pod name format. Expected <name>-<index>")
+		return 0, fmt.Errorf("invalid pod name %s. Expected <name>-<index>", podName)
 	}
 
 	indexStr := podName[lastDash+1:]
 	index, err := strconv.Atoi(indexStr)
 	if err != nil {
-		return 0, errors.New(fmt.Sprintf("invalid pod name format. Expected <name>-<index>, got %s", podName))
+		return 0, fmt.Errorf("invalid pod name format. Expected <name>-<index>, got %s", podName)
 	}
 
 	return index, nil
@@ -114,7 +114,7 @@ func main() {
 	scli.ServerMain()
 
 	// Get list of comma separated tokens from environment variable SLACK_TOKENS
-	tokens := GetSlackTokens()
+	tokens := getSlackTokens()
 
 	// Hack to get the pod index
 	// Todo: Remove this by using the label pod-index: https://github.com/kubernetes/kubernetes/pull/119232

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func podIndex() (int, error) {
 	return index, nil
 }
 
-func GetSlackTokens() []string {
+func getSlackTokens() []string {
 	tokens := os.Getenv("SLACK_TOKENS")
 	if tokens == "" {
 		return []string{}

--- a/main.go
+++ b/main.go
@@ -4,9 +4,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -52,6 +56,39 @@ type App struct {
 	channelOverride string
 }
 
+// podIndex retrieves the index of the current pod based on the HOSTNAME environment variable.
+// The function expects the HOSTNAME to be in the format <name>-<index>.
+// It returns the index as an integer and an error if any occurred during the process.
+// If the HOSTNAME environment variable is not set or if the format is invalid, it returns an error.
+func podIndex() (int, error) {
+	podName := os.Getenv("HOSTNAME")
+	if podName == "" {
+		return 0, errors.New("HOSTNAME environment variable not set")
+	}
+
+	lastDash := strings.LastIndex(podName, "-")
+	if lastDash == -1 || lastDash == len(podName)-1 {
+		return 0, errors.New("invalid pod name format. Expected <name>-<index>")
+	}
+
+	indexStr := podName[lastDash+1:]
+	index, err := strconv.Atoi(indexStr)
+	if err != nil {
+		return 0, errors.New(fmt.Sprintf("invalid pod name format. Expected <name>-<index>, got %s", podName))
+	}
+
+	return index, nil
+}
+
+func GetSlackTokens() []string {
+	tokens := os.Getenv("SLACK_TOKENS")
+	if tokens == "" {
+		return []string{}
+	}
+
+	return strings.Split(tokens, ",")
+}
+
 func main() {
 	var (
 		maxRetries          = 2
@@ -59,7 +96,6 @@ func main() {
 		slackPostMessageURL = "https://slack.com/api/chat.postMessage"
 		maxQueueSize        = 100
 		burst               = 3
-		token               string
 		metricsPort         = ":9090"
 		applicationPort     = ":8080"
 		channelOverride     string
@@ -77,10 +113,22 @@ func main() {
 
 	scli.ServerMain()
 
-	token = os.Getenv("SLACK_TOKEN")
-	if token == "" {
-		log.Fatalf("SLACK_TOKEN environment variable not set")
+	// Get list of comma separated tokens from environment variable SLACK_TOKENS
+	tokens := GetSlackTokens()
+
+	// Hack to get the pod index
+	// Todo: Remove this by using the label pod-index: https://github.com/kubernetes/kubernetes/pull/119232
+	index, err := podIndex()
+	if err != nil {
+		log.Fatalf("Failed to get pod index: %v", err)
 	}
+
+	// Get the token for the current pod
+	// If the index is out of range, we fail
+	if index >= len(tokens) {
+		log.Fatalf("Pod index %d is out of range for the list of tokens", index)
+	}
+	token := tokens[index]
 
 	// Initialize metrics
 	r := prometheus.NewRegistry()

--- a/main.go
+++ b/main.go
@@ -80,12 +80,18 @@ func podIndex() (int, error) {
 }
 
 func getSlackTokens() []string {
-	tokens := os.Getenv("SLACK_TOKENS")
-	if tokens == "" {
+	tokensEnv := os.Getenv("SLACK_TOKENS")
+	if tokensEnv == "" {
 		return []string{}
 	}
 
-	return strings.Split(tokens, ",")
+	tokens := strings.Split(tokensEnv, ",")
+
+	for i, token := range tokens {
+		tokens[i] = strings.TrimSpace(token)
+	}
+
+	return tokens
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestGetSlackTokens(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up the environment variable for the test
-			os.Setenv("SLACK_TOKENS", tt.envValue)
+			t.Setenv("SLACK_TOKENS", tt.envValue)
 
 			// Call the function
 			tokens := getSlackTokens()
@@ -86,7 +86,7 @@ func TestPodIndex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up the environment variable for the test
-			os.Setenv("HOSTNAME", tt.envValue)
+			t.Setenv("HOSTNAME", tt.envValue)
 
 			// Call the function
 			index, err := podIndex()

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestGetSlackTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected []string
+	}{
+		{
+			name:     "Multiple tokens",
+			envValue: "token1,token2,token3",
+			expected: []string{"token1", "token2", "token3"},
+		},
+		{
+			name:     "Single token",
+			envValue: "token1",
+			expected: []string{"token1"},
+		},
+		{
+			name:     "No tokens",
+			envValue: "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up the environment variable for the test
+			os.Setenv("SLACK_TOKENS", tt.envValue)
+
+			// Call the function
+			tokens := getSlackTokens()
+
+			// Check if the result matches the expected output
+			if !reflect.DeepEqual(tokens, tt.expected) {
+				t.Errorf("Expected %v, got %v", tt.expected, tokens)
+			}
+
+			// Clean up the environment variable
+			os.Unsetenv("SLACK_TOKENS")
+		})
+	}
+}
+
+func TestPodIndex(t *testing.T) {
+	tests := []struct {
+		name      string
+		envValue  string
+		expected  int
+		expectErr error
+	}{
+		{
+			name:      "Valid pod name",
+			envValue:  "pod-3",
+			expected:  3,
+			expectErr: nil,
+		},
+		{
+			name:      "Invalid pod name",
+			envValue:  "pod",
+			expected:  0,
+			expectErr: fmt.Errorf("invalid pod name %s. Expected <name>-<index>", "pod"),
+		},
+		{
+			name:      "Invalid pod index",
+			envValue:  "pod-abcde",
+			expected:  0,
+			expectErr: fmt.Errorf("invalid pod name format. Expected <name>-<index>, got %s", "pod-abcde"),
+		},
+		{
+			name:      "No pod name",
+			envValue:  "",
+			expected:  0,
+			expectErr: errors.New("HOSTNAME environment variable not set"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up the environment variable for the test
+			os.Setenv("HOSTNAME", tt.envValue)
+
+			// Call the function
+			index, err := podIndex()
+
+			// Check if an error was expected
+			if tt.expectErr != nil && err.Error() != tt.expectErr.Error() {
+				t.Errorf("Expected error %v, but got %v", tt.expectErr, err)
+			}
+
+			// Check if the result matches the expected output
+			if index != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, index)
+			}
+
+			// Clean up the environment variable
+			os.Unsetenv("HOSTNAME")
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,7 @@ func TestGetSlackTokens(t *testing.T) {
 	}{
 		{
 			name:     "Multiple tokens",
-			envValue: "token1,token2,token3",
+			envValue: "token1,token2, token3",
 			expected: []string{"token1", "token2", "token3"},
 		},
 		{


### PR DESCRIPTION
This MR adds two features:

* First is changing token to read a list of comma seperated slack tokens
* Second is to use HOSTNAME to get pod name and then get pod index based on that and select a slack token key based on that index