### PR TITLE
Fix: Fixed tests

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -40,7 +40,7 @@ func TestApp_singleBurst_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	go app.processQueue(ctx, 3, 1000, 1, 1000)
+	go app.processQueue(ctx, 3, 1000*time.Millisecond, 1, 1000*time.Millisecond)
 
 	startTime := time.Now()
 
@@ -83,7 +83,7 @@ func TestApp_MultiBurst_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	go app.processQueue(ctx, 3, 1000, 10, 1000)
+	go app.processQueue(ctx, 3, 1000*time.Millisecond, 10, 1000*time.Millisecond)
 
 	startTime := time.Now()
 
@@ -126,7 +126,7 @@ func TestApp_TestSlackRequestRate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	go app.processQueue(ctx, 3, 1000, 1, 250)
+	go app.processQueue(ctx, 3, 1000*time.Millisecond, 1, 250*time.Millisecond)
 
 	startTime := time.Now()
 

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 
 	// Define the flags with the default values // TODO: move the ones that can change to dflag
 	flag.IntVar(&maxRetries, "maxRetries", maxRetries, "Maximum number of retries for posting a message")
-	flag.Duration("initialBackoffMs", initialBackoff, "Initial backoff in milliseconds for retries")
+	flag.Duration("initialBackoff", initialBackoff, "Initial backoff in milliseconds for retries")
 	flag.Duration("slackRequestRate", slackRequestRate, "Rate limit for slack requests in milliseconds")
 	flag.StringVar(&slackPostMessageURL, "slackURL", slackPostMessageURL, "Slack Post Message API URL")
 	flag.IntVar(&maxQueueSize, "queueSize", maxQueueSize, "Maximum number of messages in the queue")

--- a/main.go
+++ b/main.go
@@ -93,20 +93,19 @@ func getSlackTokens() []string {
 func main() {
 	var (
 		maxRetries          = 2
-		initialBackoff      = 1000 * time.Millisecond
 		slackPostMessageURL = "https://slack.com/api/chat.postMessage"
 		maxQueueSize        = 100
 		burst               = 3
 		metricsPort         = ":9090"
 		applicationPort     = ":8080"
 		channelOverride     string
-		slackRequestRate    = 1000 * time.Millisecond
 	)
+
+	initialBackoff := flag.Duration("initialBackoff", 1000*time.Millisecond, "Initial backoff in milliseconds for retries")
+	slackRequestRate := flag.Duration("slackRequestRate", 1000*time.Millisecond, "Rate limit for slack requests in milliseconds")
 
 	// Define the flags with the default values // TODO: move the ones that can change to dflag
 	flag.IntVar(&maxRetries, "maxRetries", maxRetries, "Maximum number of retries for posting a message")
-	flag.Duration("initialBackoff", initialBackoff, "Initial backoff in milliseconds for retries")
-	flag.Duration("slackRequestRate", slackRequestRate, "Rate limit for slack requests in milliseconds")
 	flag.StringVar(&slackPostMessageURL, "slackURL", slackPostMessageURL, "Slack Post Message API URL")
 	flag.IntVar(&maxQueueSize, "queueSize", maxQueueSize, "Maximum number of messages in the queue")
 	flag.IntVar(&burst, "burst", burst, "Maximum number of burst to allow")
@@ -160,7 +159,7 @@ func main() {
 	defer serverCancel()
 
 	log.Infof("Starting main app logic")
-	go app.processQueue(ctx, maxRetries, initialBackoff, burst, slackRequestRate)
+	go app.processQueue(ctx, maxRetries, *initialBackoff, burst, *slackRequestRate)
 	log.Infof("Starting receiver server")
 	// Check error return of app.StartServer in go routine anon function:
 	go func() {


### PR DESCRIPTION
Fix app_tests. 

The issue was, in app tests we are using milliseconds, but when creating the process queue, we are not passing duration, but only `1000`. That makes it become microseconds, not milliseconds. Fix is to use time.millisecond with it.