### PR TITLE
Skip releaser unless it's a tag, so dependabot PRs don't fail

### DIFF
--- a/.github/workflows/include.yml
+++ b/.github/workflows/include.yml
@@ -23,6 +23,7 @@ jobs:
             contents: read
             security-events: write
     call-releaser:
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: fortio/workflows/.github/workflows/releaser.yml@main
         with:
             description: "Proxy for applications aiming to dispatch messages to Slack nicely"


### PR DESCRIPTION
other wise one gets failures like https://github.com/fortio/dnsping/actions/runs/8395565575/job/22995098122 and #53 